### PR TITLE
fix: loom.crank should not deep call

### DIFF
--- a/jquery.loom.js
+++ b/jquery.loom.js
@@ -9,10 +9,6 @@
 })(this, function (crank, weave) {
   var slice = Array.prototype.slice;
 
-  function find($element, selector) {
-    return $element.find(selector).addBack(selector);
-  }
-
   return function (attr) {
     var arg = [attr];
     var args = slice.call(arguments);
@@ -20,10 +16,10 @@
 
     return this.extend({
       "crank": function () {
-        return crank.apply(find(this, selector), arg.concat(slice.call(arguments)));
+        return crank.apply(this, arg.concat(slice.call(arguments)));
       },
       "weave": function () {
-        return weave.apply(find(this, selector), args.concat(slice.call(arguments)));
+        return weave.apply(this.find(selector).addBack(selector), args.concat(slice.call(arguments)));
       }
     });
   }

--- a/tests/index.html
+++ b/tests/index.html
@@ -20,6 +20,7 @@
   <script src="../create.js"></script>
   <script src="../jquery.wire.js"></script>
   <script src="../jquery.weave.js"></script>
+  <script src="../jquery.crank.js"></script>
   <script src="../jquery.loom.js"></script>
   <script src="expr.js"></script>
   <script src="jquery.wire.js"></script>

--- a/tests/jquery.loom.js
+++ b/tests/jquery.loom.js
@@ -93,4 +93,32 @@
       })
       .weave();
   });
+
+  QUnit.module("mu-jquery-loom/jquery.loom#crank");
+
+  QUnit.test("crank calls are not deep", function (assert) {
+    var $outer = $("<div></div>", {
+      "mu-widget": "test"
+    });
+    var $inner = $("<div></div>", {
+      "mu-widget": "test"
+    });
+    $outer.append($inner);
+
+    assert.expect(1);
+
+    return loom
+      .call($outer, "mu-widget", function () {
+        return function ($element, ns) {
+          this.$element = $element.on("test." + ns, function () {
+            assert.ok(true, "test called");
+          });
+          this.ns = ns;
+        };
+      })
+      .weave()
+      .then(function () {
+        return $outer.crank("test");
+      });
+  });
 });


### PR DESCRIPTION
At the moment `loom.crank` will try to find all widgets matching `selector` where in reality we only want to do that on our own instance.